### PR TITLE
Subtexture and Bitmap fixes

### DIFF
--- a/Pile/src/Graphics/Bitmap.bf
+++ b/Pile/src/Graphics/Bitmap.bf
@@ -130,7 +130,7 @@ namespace Pile
 		{
 			Runtime.Assert(width > 0 && height > 0, "Bitmap Width and Height need to be greater than 0");
 
-			if (!buffered && (Width != width || Height != height || Pixels == null) || Width * Height > Pixels.Count)
+			if (!buffered || ((Width != width || Height != height || Pixels == null) || Width * Height > Pixels.Count))
 			{
 				if (Pixels != null) delete Pixels;
 				Pixels = new Color[width * height];

--- a/Pile/src/Graphics/Drawing/Subtexture.bf
+++ b/Pile/src/Graphics/Drawing/Subtexture.bf
@@ -88,7 +88,7 @@ namespace Pile
 		{
 			this.texture = texture;
 			this.source = source;
-			this.frame = source;
+			this.frame = Rect(0, 0, 0, 0);
 
 			UpdateCoords();
 		}

--- a/Pile/src/Graphics/Drawing/Subtexture.bf
+++ b/Pile/src/Graphics/Drawing/Subtexture.bf
@@ -54,7 +54,6 @@ namespace Pile
 
 		public this() {}
 		public this(Texture texture) : this(texture, Rect(0, 0, texture.Width, texture.Height), Rect(0, 0, texture.Width, texture.Height)) {}
-		public this(Texture texture, Rect source) : this(texture, Rect(0, 0, source.Width, source.Height)) {}
 
 		public this(TextureView view)
 		{
@@ -64,6 +63,11 @@ namespace Pile
 
 			TexCoords = view.TexCoords;
 			DrawCoords = view.DrawCoords;
+		}
+
+		public this(Texture texture, Rect source)
+		{
+			Reset(texture, source);
 		}
 
 		public this(Texture texture, Rect source, Rect frame)
@@ -76,6 +80,15 @@ namespace Pile
 			this.texture = texture;
 			this.source = source;
 			this.frame = frame;
+
+			UpdateCoords();
+		}
+
+		public void Reset(Texture texture, Rect source)
+		{
+			this.texture = texture;
+			this.source = source;
+			this.frame = source;
 
 			UpdateCoords();
 		}


### PR DESCRIPTION
Fix infinite recursion/stack overflow with Subtexture constructor, the constructor was calling itself and blowing the stack. 

Fix bitmap not resizing properly. ResizeAndClear was not actually resizing the bitmap if size was different.